### PR TITLE
Content Field extension compatibility fix

### DIFF
--- a/lib/oembed-content.php
+++ b/lib/oembed-content.php
@@ -171,7 +171,8 @@
 				'id'		=> $values['id'],
 				'title'		=> $values['title'],
 				'driver'	=> $values['driver'],
-				'url'		=> $values['url'],
+				'url'		=> $data->{'url'},
+				'url_oembed_xml'	=> $values['url'],
 				'thumb'		=> $values['thumb'],
 				'xml'		=> $values['xml']
 			));


### PR DESCRIPTION
Fixed a bug where URL data was not saving correctly when used with the Content Field extension
