### PR TITLE
include spaces in the tag list

### DIFF
--- a/fields/field.oembed.php
+++ b/fields/field.oembed.php
@@ -576,7 +576,7 @@
 
 			$drivers = new XMLElement('div',
 				__('Supported services: <i>%s</i>',
-					array($this->get('driver'))
+					array(str_replace(',', ', ', $this->get('driver')))
 				)
 			);
 


### PR DESCRIPTION
This PR fix a issue breaking the publish page grid for mobile:

![screenshot-localhost 2015-01-16 01-42-12](https://cloud.githubusercontent.com/assets/131859/5771300/01718d92-9d21-11e4-91f8-1f2d11910790.png)

With spaces:

![screenshot-localhost 2015-01-16 01-43-41](https://cloud.githubusercontent.com/assets/131859/5771307/300bc1ae-9d21-11e4-977c-09605c2f757b.png)

Cheers! Great extension by the way!
